### PR TITLE
Fix: Match core color to background to prevent visual glitch

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -113,7 +113,7 @@
 
             // Adiciona o núcleo central para preencher os vãos
             const coreGeometry = new THREE.BoxGeometry(3, 3, 3);
-            const coreMaterial = new THREE.MeshBasicMaterial({ color: 0x101010 });
+            const coreMaterial = new THREE.MeshBasicMaterial({ color: 0x1a1a1a });
             const core = new THREE.Mesh(coreGeometry, coreMaterial);
             cubeGroup.add(core);
             


### PR DESCRIPTION
This commit resolves a visual issue where the gaps between the cube's pieces appeared to change color during rotation animations. This was caused by a mismatch between the color of the central core (`0x101010`) and the scene's background color (`0x1a1a1a`).

The fix involves updating the core's material color to exactly match the background color. This ensures a seamless visual experience, as the gaps now blend perfectly with the background, whether the cube is static or in motion.