### PR TITLE
Fix: Preserve gaps between pieces after rotation

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -52,6 +52,9 @@
         let cubeGroup, piecesGroup;
         const raycaster = new THREE.Raycaster();
         const mouse = new THREE.Vector2();
+        const pieceSize = 1;
+        const gap = 0.05;
+        const totalSize = pieceSize + gap;
 
         // Estado da interação
         let isDragging = false;
@@ -106,10 +109,6 @@
             cubeGroup = new THREE.Group();
             piecesGroup = new THREE.Group();
             cubeGroup.add(piecesGroup);
-
-            const pieceSize = 1;
-            const gap = 0.05;
-            const totalSize = pieceSize + gap;
 
             // Adiciona o núcleo central para preencher os vãos
             const coreGeometry = new THREE.BoxGeometry(3, 3, 3);
@@ -302,9 +301,11 @@ function determineAndRotateSlice(dragVector) {
                         const piece = pivot.children[0];
                         // Atualiza a matriz do objeto antes de re-anexar
                         piece.updateMatrixWorld();
-                        cubeGroup.attach(piece);
-                        // Arredonda a posição para evitar erros de ponto flutuante
-                        piece.position.round();
+                        piecesGroup.attach(piece);
+                        // Arredonda a posição para a grade com vãos
+                        piece.position.x = Math.round(piece.position.x / totalSize) * totalSize;
+                        piece.position.y = Math.round(piece.position.y / totalSize) * totalSize;
+                        piece.position.z = Math.round(piece.position.z / totalSize) * totalSize;
                     }
                     
                     scene.remove(pivot);


### PR DESCRIPTION
This commit resolves a critical issue where the gaps between the cube's pieces would disappear after a rotation animation. The previous logic incorrectly rounded the piece positions to the nearest integer, causing them to snap together and lose their intended spacing.

The fix involves the following changes:
- The `pieceSize`, `gap`, and `totalSize` variables were made global to be accessible in the animation function.
- The snapping logic in the `animateRotation` function was updated. Instead of rounding to the nearest integer, the piece positions are now snapped to a grid that accounts for the gap size. The new logic calculates the final position by rounding the position divided by `totalSize` and then multiplying by `totalSize`.

This ensures that the visual gaps between the pieces are correctly preserved after every rotation, maintaining the cube's intended appearance and resolving the user-reported issue.