### PR TITLE
Fix: Reduce core size to prevent clipping during rotation

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -111,7 +111,8 @@
             cubeGroup.add(piecesGroup);
 
             // Adiciona o núcleo central para preencher os vãos
-            const coreGeometry = new THREE.BoxGeometry(3, 3, 3);
+            const coreSize = pieceSize + 2 * gap;
+            const coreGeometry = new THREE.BoxGeometry(coreSize, coreSize, coreSize);
             const coreMaterial = new THREE.MeshBasicMaterial({ color: 0x1a1a1a });
             const core = new THREE.Mesh(coreGeometry, coreMaterial);
             cubeGroup.add(core);


### PR DESCRIPTION
This commit resolves the final visual issue where the central core of the cube was too large and would clip through the faces during rotation animations.

The fix involves adjusting the calculation for the core's size in the `createRubiksCube` function. The size is now dynamically calculated based on the `pieceSize` and `gap`, ensuring it is just large enough to fill the internal void without protruding.

This change, combined with the previous fixes to the rotation and snapping logic, completes the task. The Rubik's cube is now fully functional and visually polished.