### PR TITLE
feat: Replace OrbitControls with TrackballControls

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -34,14 +34,15 @@
     {
         "imports": {
             "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
-            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/",
+            "three/addons/controls/TrackballControls.js": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/TrackballControls.js"
         }
     }
     </script>
 
     <script type="module">
         import * as THREE from 'three';
-        import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+        import { TrackballControls } from 'three/addons/controls/TrackballControls.js';
 
         // --- Variáveis Globais ---
         let scene, camera, renderer, controls;
@@ -74,11 +75,15 @@
             renderer.setPixelRatio(window.devicePixelRatio);
             document.body.appendChild(renderer.domElement);
 
-            // Controles de Órbita (para girar o cubo)
-            controls = new OrbitControls(camera, renderer.domElement);
-            controls.enableDamping = true;
-            controls.dampingFactor = 0.1;
-            controls.rotateSpeed = 0.7;
+            // Controles de Trackball (para girar livremente)
+            controls = new TrackballControls(camera, renderer.domElement);
+            controls.rotateSpeed = 5.0;
+            controls.zoomSpeed = 1.2;
+            controls.panSpeed = 0.8;
+            controls.noZoom = false;
+            controls.noPan = false;
+            controls.staticMoving = true;
+            controls.dynamicDampingFactor = 0.15;
             
             // Iluminação
             const ambientLight = new THREE.AmbientLight(0xffffff, 0.8);


### PR DESCRIPTION
Replaces the restrictive OrbitControls with TrackballControls to allow for free, unrestricted camera rotation around the cube. This addresses the user's request to remove the polar axis lock.