### PR TITLE
fix: Disable mouse zoom and pan controls

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -150,10 +150,8 @@
             // Controles de Trackball (para girar livremente)
             controls = new TrackballControls(camera, renderer.domElement);
             controls.rotateSpeed = 5.0;
-            controls.zoomSpeed = 1.2;
-            controls.panSpeed = 0.8;
-            controls.noZoom = false;
-            controls.noPan = false;
+            controls.noZoom = true; // Desabilita o zoom pela roda do mouse
+            controls.noPan = true;  // Desabilita o pan (arrastar)
             controls.staticMoving = true;
             controls.dynamicDampingFactor = 0.15;
             


### PR DESCRIPTION
This commit disables the zoom and pan functionalities on the TrackballControls. This change ensures that the cube remains centered on the screen and that zooming is exclusively handled by the slider in the settings panel, as per the user's request.