### PR TITLE
fix: Disable browser-level zoom and pan

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Cubo 3D Interativo</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
@@ -15,6 +15,7 @@
         }
         canvas {
             display: block;
+            touch-action: none;
         }
         #info {
             position: absolute;


### PR DESCRIPTION
This commit prevents the browser's native zoom and pan functionalities. This is achieved by:
1.  Updating the viewport meta tag to set `user-scalable=no`.
2.  Adding the `touch-action: none;` CSS property to the canvas element.

These changes ensure that all page zooming is disabled, keeping the cube centered and providing a consistent user experience, as requested.