### PR TITLE
feat: Add settings modal with zoom, shuffle, and reset controls

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Cubo 3D Interativo</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
         body {
             margin: 0;
@@ -26,9 +27,121 @@
             background-color: rgba(0,0,0,0.2);
             border-radius: 10px;
         }
+        #settings-btn {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            font-size: 24px;
+            cursor: pointer;
+            z-index: 101;
+            color: #fff;
+        }
+        #settings-modal {
+            display: none;
+            position: fixed;
+            z-index: 1000;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            overflow: auto;
+            background-color: rgba(0,0,0,0.6);
+            align-items: center;
+            justify-content: center;
+        }
+        .modal-content {
+            background-color: #2a2a2a;
+            margin: auto;
+            padding: 20px;
+            border: 1px solid #888;
+            width: 80%;
+            max-width: 400px;
+            border-radius: 10px;
+            color: #fff;
+        }
+        .modal-content h2 {
+            margin-top: 0;
+        }
+        .modal-content .close-btn {
+            color: #aaa;
+            float: right;
+            font-size: 28px;
+            font-weight: bold;
+        }
+        .modal-content .close-btn:hover,
+        .modal-content .close-btn:focus {
+            color: #fff;
+            text-decoration: none;
+            cursor: pointer;
+        }
+        .slider-container {
+            margin: 20px 0;
+        }
+        .slider {
+            -webkit-appearance: none;
+            width: 100%;
+            height: 15px;
+            border-radius: 5px;
+            background: #444;
+            outline: none;
+            opacity: 0.7;
+            -webkit-transition: .2s;
+            transition: opacity .2s;
+        }
+        .slider:hover {
+            opacity: 1;
+        }
+        .slider::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            appearance: none;
+            width: 25px;
+            height: 25px;
+            border-radius: 50%;
+            background: #007bff;
+            cursor: pointer;
+        }
+        .modal-buttons {
+            display: flex;
+            justify-content: space-between;
+            margin-top: 20px;
+        }
+        .modal-buttons button {
+            padding: 10px 20px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            background-color: #007bff;
+            color: white;
+            font-size: 16px;
+        }
+        .modal-buttons button#shuffle-btn {
+            background-color: #28a745;
+        }
+        .modal-buttons button#reset-btn {
+            background-color: #dc3545;
+        }
     </style>
 </head>
 <body>
+    <div id="settings-btn">
+        <i class="fas fa-cog"></i>
+    </div>
+
+    <div id="settings-modal">
+        <div class="modal-content">
+            <span class="close-btn">&times;</span>
+            <h2>Configurações</h2>
+            <div class="slider-container">
+                <label for="zoom-slider">Zoom</label>
+                <input type="range" min="4" max="15" value="8" class="slider" id="zoom-slider">
+            </div>
+            <div class="modal-buttons">
+                <button id="shuffle-btn">Embaralhar</button>
+                <button id="reset-btn">Reiniciar</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Importmap para Three.js e OrbitControls -->
     <script type="importmap">
     {
@@ -262,8 +375,11 @@ function determineAndRotateSlice(dragVector) {
             return slice;
         }
 
-        function animateRotation(slice, axis, angle) {
-            if (isAnimating) return;
+function animateRotation(slice, axis, angle, onComplete) {
+    if (isAnimating) {
+        if (onComplete) onComplete();
+        return;
+    }
             isAnimating = true;
 
             const pivot = new THREE.Group();
@@ -315,6 +431,9 @@ function determineAndRotateSlice(dragVector) {
                     isAnimating = false;
                     saveState(); // Salva o estado após a rotação
                     controls.enabled = true; // Reativa os controles
+                    if (onComplete) {
+                        onComplete();
+                    }
                 }
             }
             requestAnimationFrame(step);
@@ -363,6 +482,79 @@ function determineAndRotateSlice(dragVector) {
 
         // --- Iniciar ---
         init();
+
+        // --- Lógica do Modal de Configurações ---
+        const settingsModal = document.getElementById('settings-modal');
+        const settingsBtn = document.getElementById('settings-btn');
+        const closeBtn = document.querySelector('.close-btn');
+
+        settingsBtn.onclick = function() {
+            settingsModal.style.display = 'flex';
+        }
+
+        closeBtn.onclick = function() {
+            settingsModal.style.display = 'none';
+        }
+
+        window.onclick = function(event) {
+            if (event.target == settingsModal) {
+                settingsModal.style.display = 'none';
+            }
+        }
+
+        // --- Lógica do Zoom ---
+        const zoomSlider = document.getElementById('zoom-slider');
+        zoomSlider.addEventListener('input', (event) => {
+            const distance = event.target.value;
+            camera.position.setLength(distance);
+        });
+
+        // --- Lógica do Shuffle ---
+        const shuffleBtn = document.getElementById('shuffle-btn');
+        shuffleBtn.addEventListener('click', () => shuffleCube(20));
+
+        function shuffleCube(moves = 20) {
+            if (isAnimating) return;
+            controls.enabled = false; // Desativa os controles durante o embaralhamento
+
+            let moveCount = 0;
+
+            function performRandomMove() {
+                if (moveCount >= moves) {
+                    controls.enabled = true; // Reativa os controles ao final
+                    saveState(); // Salva o estado final
+                    return;
+                }
+
+                const axes = [new THREE.Vector3(1, 0, 0), new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 1)];
+                const axis = axes[Math.floor(Math.random() * axes.length)];
+
+                const sliceIndices = [-1, 0, 1];
+                const sliceIndex = sliceIndices[Math.floor(Math.random() * sliceIndices.length)];
+
+                // Posição para selecionar a fatia
+                const position = axis.clone().multiplyScalar(sliceIndex * totalSize);
+
+                const slice = getSlice(axis, position);
+
+                const angles = [Math.PI / 2, -Math.PI / 2];
+                const angle = angles[Math.floor(Math.random() * angles.length)];
+
+                moveCount++;
+
+                // Anima a rotação e chama o próximo movimento ao completar
+                animateRotation(slice, axis, angle, performRandomMove);
+            }
+
+            performRandomMove();
+        }
+
+        // --- Lógica do Reset ---
+        const resetBtn = document.getElementById('reset-btn');
+        resetBtn.addEventListener('click', () => {
+            localStorage.removeItem('rubiksCubeState');
+            location.reload();
+        });
 
     </script>
 </body>


### PR DESCRIPTION
This commit introduces a new settings modal that provides the user with more control over the Rubik's cube.

Key features added:
- A settings button (using Font Awesome) that toggles a modal window.
- A zoom slider within the modal to control the camera's distance from the cube.
- A "Shuffle" button that performs 20 random rotations to scramble the cube.
- A "Reset" button that clears the cube's state from localStorage and reloads the page to return it to the solved state.