### PR TITLE
fix: Ensure success modal appears after solving a shuffled cube

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -518,8 +518,8 @@ function animateRotation(slice, axis, angle, onComplete) {
                         stopTimer(); // Para o cronômetro e atualiza o `elapsedTime` global.
                         document.getElementById('final-time').textContent = formatTime(elapsedTime); // Usa o `elapsedTime` global.
                         document.getElementById('results-modal').style.display = 'flex';
-                    } else {
-                        controls.enabled = true; // Só reativa se o cubo não estiver resolvido
+                    } else if (!isShuffling) {
+                        controls.enabled = true; // Só reativa se o cubo não estiver resolvido E não estiver embaralhando
                     }
 
                     if (onComplete) {


### PR DESCRIPTION
This commit fixes a bug where the success modal ("Parabéns!") would not appear if the user solved the cube after it had been shuffled.

The root cause was a race condition where the camera controls were being re-enabled during the shuffle animation. This allowed the user to interact with the cube while the `isShuffling` flag was still true, which prevented the timer from starting. Consequently, the `elapsedTime` remained at 0, and the condition to show the success modal (`checkIfSolved() && elapsedTime > 0`) would never be met.

The fix prevents the controls from being re-enabled within the `animateRotation` function while a shuffle is in progress. The responsibility for re-enabling controls is now solely with the `shuffleCube` function, which does so after the entire animation sequence is complete.