### PR TITLE
fix: Timer does not stop after solving a shuffled cube

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -606,7 +606,8 @@ function animateRotation(slice, axis, angle, onComplete) {
         // --- Funções de Estado ---
         function checkIfSolved() {
             // A cube is solved if every piece is in its original position and orientation.
-            const epsilon = 0.01;
+            // Increased epsilon to account for floating-point inaccuracies after many rotations.
+            const epsilon = 0.1;
             const identityQuaternion = new THREE.Quaternion();
 
             for (const piece of piecesGroup.children) {


### PR DESCRIPTION
This commit resolves a bug where the timer would not stop, and the success modal would not appear, after the user solved a cube that had been shuffled.

The root cause was determined to be an accumulation of floating-point precision errors during the multiple rotations of the shuffle animation. These small errors caused the `checkIfSolved` function to fail, as the final piece positions and orientations did not exactly match the ideal solved state, even though they appeared correct visually.

The fix increases the tolerance (`epsilon`) within the `checkIfSolved` function from `0.01` to `0.1`. This makes the check more robust and allows it to correctly identify the solved state by accommodating the minor floating-point inaccuracies that can occur after numerous transformations.