### PR TITLE
fix(timer): Garante que o cronômetro pare na resolução do cubo

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -517,8 +517,8 @@ function animateRotation(slice, axis, angle, onComplete) {
                     isAnimating = false;
                     saveState(); // Salva o estado após a rotação
 
-                    // A verificação `elapsedTime > 0` usa a variável global do cronômetro.
-                    if (checkIfSolved() && elapsedTime > 0) {
+                    // A verificação do tempo foi removida para garantir que a conclusão seja sempre registrada.
+                    if (checkIfSolved()) {
                         stopTimer(); // Para o cronômetro e atualiza o `elapsedTime` global.
                         document.getElementById('final-time').textContent = formatTime(elapsedTime); // Usa o `elapsedTime` global.
                         document.getElementById('results-modal').style.display = 'flex';


### PR DESCRIPTION
Remove a verificação `elapsedTime > 0` da condição de conclusão. Isso garante que o modal de resultados seja exibido e o cronômetro pare sempre que o cubo atingir o estado resolvido, mesmo que a página tenha sido recarregada durante a resolução.

O problema ocorria porque, ao recarregar a página, o `elapsedTime` era restaurado do `localStorage`, mas a lógica de animação não o atualizava antes da verificação, fazendo com que a condição `checkIfSolved() && elapsedTime > 0` falhasse. A remoção da verificação de tempo resolve o problema de forma robusta, pois a única condição para parar o cronômetro deve ser o estado resolvido do cubo.